### PR TITLE
add `RouterEventFirehose` protocol 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: objective-c
 osx_image: xcode7.2
 
 install: 
-  - git clone https://github.com/TheHolyGrail/ELFoundation.git ../ELFoundation
-  - git clone https://github.com/TheHolyGrail/ELDispatch.git ../ELDispatch
-  - git clone https://github.com/TheHolyGrail/ELLog.git ../ELLog
+  - git clone https://github.com/Electrode-iOS/ELFoundation.git ../ELFoundation
+  - git clone https://github.com/Electrode-iOS/ELDispatch.git ../ELDispatch
+  - git clone https://github.com/Electrode-iOS/ELLog.git ../ELLog
 script:
    - xctool -project ELRouter.xcodeproj -scheme ELRouter -sdk iphonesimulator build test

--- a/ELRouter/Router.swift
+++ b/ELRouter/Router.swift
@@ -18,6 +18,11 @@ public class Router: NSObject {
     public var routes: [Route] {
         return masterRoute.subRoutes
     }
+    public weak var eventFirehose: RouterEventFirehose? {
+        didSet {
+            NavSync.sharedInstance.eventFirehose = eventFirehose
+        }
+    }
     private let masterRoute: Route = Route("MASTER", type: .Other)
     private var translation = [String : String]()
 }


### PR DESCRIPTION
enables external objects to subscribe to a firehose of Router events