### PR TITLE
routeByEnum refactoring

### DIFF
--- a/ELRouter.xcodeproj/project.xcworkspace/xcshareddata/ELRouter.xcscmblueprint
+++ b/ELRouter.xcodeproj/project.xcworkspace/xcshareddata/ELRouter.xcscmblueprint
@@ -4,18 +4,18 @@
 
   },
   "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey" : {
-    "17104B2A3601E088F12BC3FD57E01F7420137173" : 0,
-    "8793D34A7BF94DA191D8F935B1E0425A8C1B2681" : 0,
-    "ABC43406D9D37932D5E4C9F5487AFE570D641A31" : 0,
     "7D51FEE86695D298E2BDAEA0A5938727BE31AF7D" : 0,
+    "ABC43406D9D37932D5E4C9F5487AFE570D641A31" : 0,
+    "25CFE4C5E7BA82B1D00A2219D91AA3FE715B64C9" : 0,
+    "8793D34A7BF94DA191D8F935B1E0425A8C1B2681" : 0,
     "F75375CB2C82D2BC362ACFD0392481707735854D" : 0
   },
   "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "306787B9-ACA8-4DD2-BB8D-72187FC89BC4",
   "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
-    "17104B2A3601E088F12BC3FD57E01F7420137173" : "..",
-    "8793D34A7BF94DA191D8F935B1E0425A8C1B2681" : "ELFoundation\/",
-    "ABC43406D9D37932D5E4C9F5487AFE570D641A31" : "ELRouter\/",
     "7D51FEE86695D298E2BDAEA0A5938727BE31AF7D" : "ELDispatch\/",
+    "ABC43406D9D37932D5E4C9F5487AFE570D641A31" : "ELRouter\/",
+    "25CFE4C5E7BA82B1D00A2219D91AA3FE715B64C9" : "..",
+    "8793D34A7BF94DA191D8F935B1E0425A8C1B2681" : "ELFoundation\/",
     "F75375CB2C82D2BC362ACFD0392481707735854D" : "ELLog\/"
   },
   "DVTSourceControlWorkspaceBlueprintNameKey" : "ELRouter",
@@ -25,7 +25,7 @@
     {
       "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:walmartlabs-wmusiphone\/walmart-ios.git",
       "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
-      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "17104B2A3601E088F12BC3FD57E01F7420137173"
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "25CFE4C5E7BA82B1D00A2219D91AA3FE715B64C9"
     },
     {
       "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:Electrode-iOS\/ELDispatch.git",

--- a/ELRouter/Router.swift
+++ b/ELRouter/Router.swift
@@ -12,6 +12,13 @@ import ELDispatch
 
 public typealias RouteCompletion = () -> Void
 
+// Swift will automatically assign Int values,
+// but if we annotate them in comments, it may be easier
+// to debug
+@objc enum RouterError: Int, ErrorType {
+    case RouteNotFound // 0
+}
+
 ///
 @objc
 public class Router: NSObject {
@@ -195,13 +202,19 @@ extension Router {
 
 extension Router {
     /**
-     Get all routes for a particular RouteEnum
+     Get the route for a particular RouteEnum
     
-     - parameter routeEnum: The enum of the routes to get
- 
+     - parameter routeEnum: The enum of the route to get
     */
-    public func routesByEnum(routeEnum: RouteEnum) -> [Route] {
-        return routes.filterByName(routeEnum.spec.name)
+    public func routeByEnum(routeEnum: RouteEnum) throws -> Route {
+        let filteredRoutes = routes.filterByName(routeEnum.spec.name)
+        // Brandon's design is such that a route should only match 1
+        switch filteredRoutes.count {
+        case 1:
+            return filteredRoutes[0]
+        default:
+            throw(RouterError.RouteNotFound)
+        }
     }
     
     /**

--- a/ELRouter/Router.swift
+++ b/ELRouter/Router.swift
@@ -195,11 +195,23 @@ extension Router {
 
 extension Router {
     /**
+     Get all routes for a particular RouteEnum
+    
+     - parameter routeEnum: The enum of the routes to get
+ 
+    */
+    public func routesByEnum(routeEnum: RouteEnum) -> [Route] {
+        return routes.filterByName(routeEnum.spec.name)
+    }
+    
+    /**
      Get all routes of a particular name.
+     
+     This function is marked internal to prevent API abuse
      
      - parameter name: The name of the routes to get.
     */
-    public func routesByName(name: String) -> [Route] {
+    internal func routesByName(name: String) -> [Route] {
         return routes.filterByName(name)
     }
     

--- a/ELRouterTests/RouterTests.swift
+++ b/ELRouterTests/RouterTests.swift
@@ -786,7 +786,7 @@ extension RouterTests {
                 return didRun == true
             })
         } catch {
-            print("OMG1!!!")
+            print("check the main name error \(error)")
         }
         XCTAssertTrue(didRun)
         
@@ -798,7 +798,7 @@ extension RouterTests {
                 return didRun == true
             })
         } catch {
-            print("OMG2!!!")
+            print("check the alias error \(error)")
         }
         XCTAssertTrue(evaluated)
         XCTAssertTrue(didRun)

--- a/ELRouterTests/RouterTests.swift
+++ b/ELRouterTests/RouterTests.swift
@@ -782,7 +782,7 @@ extension RouterTests {
         // check the main name.
         router.evaluateURLString("walmart://foo/1234/5678")
         do {
-            try waitForConditionsWithTimeout(2.0, conditionsCheck: { () -> Bool in
+            try waitForConditionsWithTimeout(5.0, conditionsCheck: { () -> Bool in
                 return didRun == true
             })
         } catch {
@@ -792,14 +792,20 @@ extension RouterTests {
         
         // check the alias
         didRun = false
+        let startTime = NSDate()
         let evaluated = router.evaluateURLString("walmart://bar/1234/5678")
         do {
-            try waitForConditionsWithTimeout(2.0, conditionsCheck: { () -> Bool in
+            try waitForConditionsWithTimeout(5.0, conditionsCheck: { () -> Bool in
                 return didRun == true
             })
         } catch {
             print("check the alias error \(error)")
         }
+    
+        let endTime = NSDate()
+        let deltaTime = endTime.timeIntervalSinceDate(startTime)
+        print("startTime: \(startTime), endTime: \(endTime), deltaTime:\(deltaTime)")
+
         XCTAssertTrue(evaluated)
         XCTAssertTrue(didRun)
         

--- a/ELRouterTests/RouterTests.swift
+++ b/ELRouterTests/RouterTests.swift
@@ -10,6 +10,20 @@ import XCTest
 @testable import ELRouter
 import ELFoundation
 
+enum TestRoutes: RouteEnum {
+    case Home
+    case ScreenOne
+    case ScreenTwo
+    
+    var spec: RouteSpec {
+        switch self {
+        case .Home: return (name: "home", type: .Static, example: "home://")
+        case .ScreenOne: return (name: "screen-one", type: .Static, example: "screenone://")
+        case .ScreenTwo: return (name: "screen-two", type: .Static, example: "screentwo://")
+        }
+    }
+}
+
 // MARK: - translate Tests
 
 class RouterTests: XCTestCase {
@@ -844,4 +858,45 @@ extension RouterTests {
 //        
 //        XCTAssertNil(navigator.testNavigationController?.topViewController?.presentedViewController)
 //    }
+}
+
+// MARK: Enum Tests
+
+extension RouterTests {
+
+    // Test routeByEnum success
+    func testRouteByEnumFoundEnum() {
+        let router = Router()
+
+        let homeRoute = Route(TestRoutes.Home) { (_, _) in
+            return nil
+        }
+        router.register(homeRoute)
+        
+        do {
+            let foundHomeRoute = try router.routeByEnum(TestRoutes.Home)
+            XCTAssert(foundHomeRoute == homeRoute, "Routes do not match")
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+    
+    // Test routeByEnum failure to find a route
+    func testRouteByEnumMissingEnum() {
+        let router = Router()
+        
+        let homeRoute = Route(TestRoutes.Home) { (_, _) in
+            return nil
+        }
+        router.register(homeRoute)
+        
+        do {
+            let _ = try router.routeByEnum(TestRoutes.ScreenOne)
+            XCTFail("Should not have reached this code)")
+        } catch RouterError.RouteNotFound {
+            // succcess
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
 }


### PR DESCRIPTION
Contains breaking changes.

internalized routeByName to discourage external use. Implemented routeByEnum which throws an error if the route is not found.

Added RouterError which is accessible from Obj-C as well as Swift

Added unit tests for new API.

Changed existing unit test to try and resolve travis timeout. Added timing debugging code in case future unit tests timeout.