### PR TITLE
Add routeByEnum, internalizing routeByName

### DIFF
--- a/ELRouter.xcodeproj/project.xcworkspace/xcshareddata/ELRouter.xcscmblueprint
+++ b/ELRouter.xcodeproj/project.xcworkspace/xcshareddata/ELRouter.xcscmblueprint
@@ -4,18 +4,18 @@
 
   },
   "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey" : {
-    "17104B2A3601E088F12BC3FD57E01F7420137173" : 0,
-    "8793D34A7BF94DA191D8F935B1E0425A8C1B2681" : 0,
-    "ABC43406D9D37932D5E4C9F5487AFE570D641A31" : 0,
     "7D51FEE86695D298E2BDAEA0A5938727BE31AF7D" : 0,
+    "ABC43406D9D37932D5E4C9F5487AFE570D641A31" : 0,
+    "25CFE4C5E7BA82B1D00A2219D91AA3FE715B64C9" : 0,
+    "8793D34A7BF94DA191D8F935B1E0425A8C1B2681" : 0,
     "F75375CB2C82D2BC362ACFD0392481707735854D" : 0
   },
   "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "306787B9-ACA8-4DD2-BB8D-72187FC89BC4",
   "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
-    "17104B2A3601E088F12BC3FD57E01F7420137173" : "..",
-    "8793D34A7BF94DA191D8F935B1E0425A8C1B2681" : "ELFoundation\/",
-    "ABC43406D9D37932D5E4C9F5487AFE570D641A31" : "ELRouter\/",
     "7D51FEE86695D298E2BDAEA0A5938727BE31AF7D" : "ELDispatch\/",
+    "ABC43406D9D37932D5E4C9F5487AFE570D641A31" : "ELRouter\/",
+    "25CFE4C5E7BA82B1D00A2219D91AA3FE715B64C9" : "..",
+    "8793D34A7BF94DA191D8F935B1E0425A8C1B2681" : "ELFoundation\/",
     "F75375CB2C82D2BC362ACFD0392481707735854D" : "ELLog\/"
   },
   "DVTSourceControlWorkspaceBlueprintNameKey" : "ELRouter",
@@ -25,7 +25,7 @@
     {
       "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:walmartlabs-wmusiphone\/walmart-ios.git",
       "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
-      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "17104B2A3601E088F12BC3FD57E01F7420137173"
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "25CFE4C5E7BA82B1D00A2219D91AA3FE715B64C9"
     },
     {
       "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:Electrode-iOS\/ELDispatch.git",

--- a/ELRouter/Router.swift
+++ b/ELRouter/Router.swift
@@ -130,10 +130,12 @@ extension Router {
 
 // MARK: - Evaluating Routes
 extension Router {
-    /**
-     Can be used to determine if Routes are currently be processed.
-     */
-    public var processing: Bool {
+    // This must not be used externally to determine if routes are processing
+    // Due to threading, this may evaluate late compared in successive
+    // execute commands due to thread switching to main on route evaluation
+    // It is better to use the RouteCompletion block on the evaluate
+    // function
+    var processing: Bool {
         var result = false
         synchronized(self) { () -> Void in
             result = (Router.routesInFlight != nil)
@@ -195,14 +197,19 @@ extension Router {
 
 extension Router {
     /**
-     Get all routes for a particular RouteEnum
+     Get the route for a particular RouteEnum
     
-     - parameter routeEnum: The enum of the routes to get
- 
+     - parameter routeEnum: The enum of the route to get
     */
-    public func routesByEnum(routeEnum: RouteEnum) -> [Route] {
-        return routes.filterByName(routeEnum.spec.name)
-    }
+    public func routeByEnum(routeEnum: RouteEnum) -> Route? {
+        let filteredRoutes = routes.filterByName(routeEnum.spec.name)
+        // Brandon's design is such that a route should only match 1
+        if filteredRoutes.count == 1 {
+            return filteredRoutes[0]
+        }
+        
+        return nil
+     }
     
     /**
      Get a route of a particular name.
@@ -267,6 +274,14 @@ extension Router {
 
 extension Router {
     internal static let lock = Spinlock()
+    
+    // TODO: Consider making this a non-static, as it is fragile
+    // If the thread processing the routes is killed (say a unit test terminates early)
+    // then this static is never nilled out, and the processing computed variable
+    // will always be true
+    // I believe (this is a guess) that the author's intention was to make sure
+    // that two routers could not execute routes at the same time
+    // I suggest we find a more Swifty way to handle this concern
     private static var routesInFlight: [Route]? = nil
     
     // this function is for internal use and testability, DO NOT MAKE IT PUBLIC.
@@ -281,6 +296,7 @@ extension Router {
         // if we have routes in flight, return false.  We can't do anything
         // until those have finished.
         if processing {
+            log(.Debug, "Already processing route. Aborting.")
             return false
         }
         
@@ -317,6 +333,7 @@ extension Router {
     
     internal func serializedRoute(routes: [Route], components: [String], associatedData: AssociatedData?, animated: Bool, completion: RouteCompletion? = nil) {
         if processing {
+            log(.Debug, "Already processing route. Aborting.")
             return
         }
         
@@ -353,14 +370,17 @@ extension Router {
                 }
             }
             
-            if let completionClosure = completion {
-                completionClosure()
-            }
-            
             // clear our in-flight routes now that we're done.
             synchronized(self) {
                 Router.routesInFlight = nil
             }
+            
+            // The completion block needs to run last, because
+            // user code may trigger termination of the thread
+            // If that happens, the static routesInFlight variable won't
+            // be nilled out, and then all future routes will fail
+            completion?()
+            
         }
     }
 }

--- a/ELRouter/Router.swift
+++ b/ELRouter/Router.swift
@@ -195,11 +195,23 @@ extension Router {
 
 extension Router {
     /**
+     Get all routes for a particular RouteEnum
+    
+     - parameter routeEnum: The enum of the routes to get
+ 
+    */
+    public func routesByEnum(routeEnum: RouteEnum) -> [Route] {
+        return routes.filterByName(routeEnum.spec.name)
+    }
+    
+    /**
      Get all routes of a particular name.
+     
+     This function is marked internal to prevent API abuse
      
      - parameter name: The name of the routes to get.
     */
-    public func routesByName(name: String) -> [Route] {
+    internal func routesByName(name: String) -> [Route] {
         return routes.filterByName(name)
     }
     


### PR DESCRIPTION
### Deprecations

- Deprecated `routeByName` and marked `internal`. Use `routeByEnum` instead

### New Features

- Added `routeByEnum(routeEnum:) -> throws` Returns a single route for a give route enumeration

- Added `.Alias` route type. Return an existing route to be used in place of this route.

### Fixes

- Increased asynchronous test timeouts to 15 seconds to reduce false negative results on some testing hosts

- Static routes now call popToRootViewController if the route's viewController is a UINavigationController