### PR TITLE
changed deepLinkComponents to not unencode escaped slashes when deter…

### DIFF
--- a/ELRouter/NSURL+DeepLink.swift
+++ b/ELRouter/NSURL+DeepLink.swift
@@ -21,8 +21,9 @@ public extension NSURL {
         }
 
         // now add the path components, leaving the encoded parts intact
-        if let validRelativeString = relativeString,
-               urlComponents = NSURLComponents(string: validRelativeString),
+        let optionalAbsoluteString: String? = absoluteString // gotta do this for backward compatability with iOS 9, where absoluteString is not optional like it is in iOS 10
+        if let validAbsoluteString = optionalAbsoluteString,
+               urlComponents = NSURLComponents(string: validAbsoluteString),
                percentEncodedPath = urlComponents.percentEncodedPath
         {
             // Note that the percentEncodedPath property of NSURLComponents does not add any encoding, it just returns any

--- a/ELRouter/NSURL+DeepLink.swift
+++ b/ELRouter/NSURL+DeepLink.swift
@@ -10,8 +10,8 @@ import Foundation
 
 public extension NSURL {
     public var deepLinkComponents: [String]? {
-        guard let pathComponents = pathComponents else { return nil }
-        
+        guard let _ = pathComponents else { return nil }
+
         // a deep link doesn't have the notion of a host, construct it as such
         var components = [String]()
         
@@ -19,10 +19,22 @@ public extension NSURL {
         if let host = host {
             components.append(host)
         }
-        
-        // out "/" and append our components
-        components.appendContentsOf(pathComponents.filter { !($0 == "/") })
-        
+
+        // now add the path components, leaving the encoded parts intact
+        if let validRelativeString = relativeString,
+               urlComponents = NSURLComponents(string: validRelativeString),
+               percentEncodedPath = urlComponents.percentEncodedPath
+        {
+            // Note that the percentEncodedPath property of NSURLComponents does not add any encoding, it just returns any
+            // encoding that is already in the path. Unencoded slashes will remain unencoded but escaped slashes will remain
+            // escaped, which is what we want here.
+            let pathComponents = percentEncodedPath.componentsSeparatedByString("/")
+            // remove any empty strings, such as the one in the first element that results from the initial slash
+            let pathComponentsAfterSlash = pathComponents.filter() { !$0.isEmpty }
+            // append to our components
+            components += pathComponentsAfterSlash
+        }
+
         return components
     }
     

--- a/ELRouterTests/NSURLDeepLinkTests.swift
+++ b/ELRouterTests/NSURLDeepLinkTests.swift
@@ -21,7 +21,18 @@ class NSURLDeepLinkTests: XCTestCase {
         XCTAssertEqual(components![1], "bar")
         XCTAssertEqual(components![2], "foo")
     }
-    
+
+    func test_deepLinkComponents_encodedPathPartsAreRetained() {
+        let url = NSURL(string: "scheme://webview/https%3A%2F%2Fwww.foo.com%2Fbar")!
+        
+        let components = url.deepLinkComponents
+        
+        XCTAssertNotNil(components)
+        XCTAssertEqual(components!.count, 2)
+        XCTAssertEqual(components![0], "webview")
+        XCTAssertEqual(components![1], "https%3A%2F%2Fwww.foo.com%2Fbar")
+    }
+
     func test_deepLinkComponents_hostIsIncludedInComponents() {
         let url = NSURL(string: "scheme://walmart.com")!
         let host = url.host!


### PR DESCRIPTION
…mining path components, but to pass encoded parts on instead