### PR TITLE
Update Route.swift to pass associatedData to .fixed routes

### DIFF
--- a/ELRouter/Route.swift
+++ b/ELRouter/Route.swift
@@ -172,6 +172,7 @@ open class Route: NSObject {
 
         if let navigator = parentRouter?.navigator {
             if let staticValue = staticValue {
+                 _ = action(variable, remainingComponents, &associatedData)
                 result = staticValue
                 if let vc = staticValue as? UIViewController {
                     parentRouter?.navigator?.selectedViewController = vc


### PR DESCRIPTION
When a .fixed route is created, staticValue is set to the result returned by action(), and then action() is never called again.  This makes it impossible to pass associated data to such routes.  Proposed change adds this functionality, and indeed it might be better to just set `result = action(variable, remainingComponents, &associatedData)` and remove the following line.